### PR TITLE
fix(runtime): preserve authorization-like prose

### DIFF
--- a/packages/runtime/src/__tests__/acpProtocolRedaction.test.ts
+++ b/packages/runtime/src/__tests__/acpProtocolRedaction.test.ts
@@ -2,10 +2,64 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { normalizeAcpSessionNotification } from "../autoRun/acpEventNormalization.js";
 import { AcpEventStore } from "../autoRun/acpEventStore.js";
 import { runnerIdentitySchema, runnerRunIdentitySchema } from "../autoRun/runnerContractSchemas.js";
 
 describe("ACP protocol persistence redaction", () => {
+  it("persists ordinary Basic text without treating it as a credential", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "planweave-acp-basic-prose-"));
+    const store = new AcpEventStore({
+      runDir,
+      identity: runnerRunIdentitySchema.parse({
+        projectId: "project-1",
+        canvasId: "default",
+        taskId: "T-002",
+        blockId: "B-002",
+        claimRef: "T-002#B-002",
+        runId: "RUN-001",
+        runOwner: "executor",
+        runSessionId: null,
+        desktopRunId: null,
+        executorRunId: "RUN-001"
+      }),
+      runner: runnerIdentitySchema.parse({
+        version: "planweave.runner/v1",
+        runnerKind: "acp",
+        agentId: "codex"
+      })
+    });
+    expect(await store.open()).toEqual([]);
+    const notification = {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update" as const,
+        toolCallId: "tool-1",
+        status: "completed" as const,
+        rawOutput: {
+          formatted_output: '{"project":{"title":"Basic PlanWeave Example"}}',
+          exit_code: 0
+        }
+      }
+    };
+    await store.appendProtocol("agent_to_client", {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: notification
+    });
+    const normalized = normalizeAcpSessionNotification(notification);
+    expect(normalized).not.toBeNull();
+    if (normalized) await store.append(normalized, { sessionId: "session-1" });
+    await store.drain();
+
+    const protocol = await readFile(join(runDir, "protocol.ndjson"), "utf8");
+    const events = await readFile(join(runDir, "events.ndjson"), "utf8");
+    expect(protocol).toContain("Basic PlanWeave Example");
+    expect(events).toContain("Basic PlanWeave Example");
+    expect(protocol).not.toContain("[REDACTED:CREDENTIAL]");
+    expect(events).not.toContain("[REDACTED:CREDENTIAL]");
+  });
+
   it("fails closed for malformed terminal authentication methods", async () => {
     const runDir = await mkdtemp(join(tmpdir(), "planweave-acp-auth-redaction-"));
     const store = new AcpEventStore({

--- a/packages/runtime/src/__tests__/runnerContracts.test.ts
+++ b/packages/runtime/src/__tests__/runnerContracts.test.ts
@@ -308,28 +308,19 @@ describe("runner event redaction and UTF-8 limits", () => {
     });
   });
 
-  it("preserves ordinary Bearer prose while redacting Bearer credentials", () => {
+  it("keeps standalone Bearer credentials fail-closed", () => {
     for (const content of [
-      "Bearer responsibilities overview",
-      "Bearer abcdefgh overview",
-      "Bearer plan-weave overview"
+      "Bearer abcdefgh",
+      "Bearer AbCdEfGhIjKlMnOp",
+      "Bearer abc.def.ghi",
+      "Bearer abcdefghijklmnopqrstuvwx"
     ]) {
       expect(redactRunnerEventText(content)).toEqual({
-        text: content,
-        classes: [],
-        replaced: 0
+        text: "[REDACTED:CREDENTIAL]",
+        classes: ["credential"],
+        replaced: 1
       });
     }
-    expect(redactRunnerEventText("Bearer abc.def.ghi")).toEqual({
-      text: "[REDACTED:CREDENTIAL]",
-      classes: ["credential"],
-      replaced: 1
-    });
-    expect(redactRunnerEventText("Bearer abcdefghijklmnopqrstuvwx")).toEqual({
-      text: "[REDACTED:CREDENTIAL]",
-      classes: ["credential"],
-      replaced: 1
-    });
   });
 
   it("derives the encoded JSONL record limit from the shared line contract", () => {

--- a/packages/runtime/src/__tests__/runnerContracts.test.ts
+++ b/packages/runtime/src/__tests__/runnerContracts.test.ts
@@ -37,6 +37,7 @@ import {
 import { adaptLegacyDesktopRunnerEvents } from "../desktop/legacyRunnerEventAdapter.js";
 import {
   redactAcpProtocolPayload,
+  redactRunnerEventText,
   redactRunnerEventPayload
 } from "../autoRun/runnerEventRedaction.js";
 
@@ -286,6 +287,51 @@ describe("runner identity and capability contracts", () => {
 });
 
 describe("runner event redaction and UTF-8 limits", () => {
+  it("preserves ordinary Basic prose while redacting Basic credentials", () => {
+    for (const content of [
+      "Basic PlanWeave Example",
+      "Basic PlanWeave",
+      "basic experience overview",
+      "The basic workflow is clear",
+      "basic abcdefgh overview"
+    ]) {
+      expect(redactRunnerEventText(content)).toEqual({
+        text: content,
+        classes: [],
+        replaced: 0
+      });
+    }
+    expect(redactRunnerEventText("Basic dXNlcjpwYXNz")).toEqual({
+      text: "[REDACTED:CREDENTIAL]",
+      classes: ["credential"],
+      replaced: 1
+    });
+  });
+
+  it("preserves ordinary Bearer prose while redacting Bearer credentials", () => {
+    for (const content of [
+      "Bearer responsibilities overview",
+      "Bearer abcdefgh overview",
+      "Bearer plan-weave overview"
+    ]) {
+      expect(redactRunnerEventText(content)).toEqual({
+        text: content,
+        classes: [],
+        replaced: 0
+      });
+    }
+    expect(redactRunnerEventText("Bearer abc.def.ghi")).toEqual({
+      text: "[REDACTED:CREDENTIAL]",
+      classes: ["credential"],
+      replaced: 1
+    });
+    expect(redactRunnerEventText("Bearer abcdefghijklmnopqrstuvwx")).toEqual({
+      text: "[REDACTED:CREDENTIAL]",
+      classes: ["credential"],
+      replaced: 1
+    });
+  });
+
   it("derives the encoded JSONL record limit from the shared line contract", () => {
     expect(RUNNER_EVENT_MAX_ENCODED_BYTES).toBe(
       RUNNER_EVENT_MAX_LINE_BYTES + Buffer.byteLength("\n")
@@ -294,6 +340,7 @@ describe("runner event redaction and UTF-8 limits", () => {
 
   it.each([
     ["Authorization: Basic dXNlcjpwYXNz", ["dXNlcjpwYXNz"]],
+    ["Authorization: Bearer abcdefgh", ["abcdefgh"]],
     ["Authorization: Bearer abc.def.ghi", ["abc.def.ghi"]],
     ["api_key=alpha beta", ["alpha", "beta"]],
     ['password: "hunter two"', ["hunter", "two"]],

--- a/packages/runtime/src/__tests__/runnerEventRedactionBrowser.test.ts
+++ b/packages/runtime/src/__tests__/runnerEventRedactionBrowser.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { safeRunnerEventTextSchema, utf8ByteLength } from "../autoRun/runnerEventRedaction.js";
+import {
+  redactRunnerEventText,
+  safeRunnerEventTextSchema,
+  utf8ByteLength
+} from "../autoRun/runnerEventRedaction.js";
 
 describe("runner event redaction browser compatibility", () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -10,5 +14,10 @@ describe("runner event redaction browser compatibility", () => {
     expect(utf8ByteLength("PlanWeave 界")).toBe(13);
     expect(safeRunnerEventTextSchema(3, "message").safeParse("界").success).toBe(true);
     expect(safeRunnerEventTextSchema(2, "message").safeParse("界").success).toBe(false);
+    expect(redactRunnerEventText("Basic dXNlcjpwYXNz")).toEqual({
+      text: "[REDACTED:CREDENTIAL]",
+      classes: ["credential"],
+      replaced: 1
+    });
   });
 });

--- a/packages/runtime/src/autoRun/runnerEventRedaction.ts
+++ b/packages/runtime/src/autoRun/runnerEventRedaction.ts
@@ -17,8 +17,6 @@ const sensitiveLabelPattern =
   /\b(?:client[_-]?secret|session[_-]?cookie|set-cookie|cookie)\s*[:=]\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\r\n,;]+)/gi;
 const standaloneBasicAuthorizationPattern = /\bbasic\s+[A-Za-z0-9+/]+={0,2}/gi;
 const standaloneBearerAuthorizationPattern = /\bbearer\s+[A-Za-z0-9._~+/=-]{8,}/gi;
-const minimumOpaqueBearerTokenLength = 24;
-const minimumBearerTokenSeparators = 2;
 const privateKeyPattern =
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|$)/g;
 const privateKeyMarkerPattern = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i;
@@ -45,16 +43,6 @@ function isBasicCredential(match: string): boolean {
   } catch {
     return false;
   }
-}
-
-function isBearerCredential(match: string): boolean {
-  const token = standaloneAuthorizationToken(match);
-  const separators = token.match(/[._~+/=-]/g)?.length ?? 0;
-  return (
-    token.length >= minimumOpaqueBearerTokenLength ||
-    /[0-9]/.test(token) ||
-    separators >= minimumBearerTokenSeparators
-  );
 }
 
 const redactionRules: readonly RedactionRule[] = [
@@ -102,8 +90,7 @@ const redactionRules: readonly RedactionRule[] = [
   {
     pattern: standaloneBearerAuthorizationPattern,
     classification: "credential",
-    replacement: "[REDACTED:CREDENTIAL]",
-    shouldRedact: isBearerCredential
+    replacement: "[REDACTED:CREDENTIAL]"
   }
 ];
 

--- a/packages/runtime/src/autoRun/runnerEventRedaction.ts
+++ b/packages/runtime/src/autoRun/runnerEventRedaction.ts
@@ -15,7 +15,10 @@ const jsonEnvironmentCredentialPattern =
   /["'](?:[A-Z_][A-Z0-9_]*_)?(?:API_KEY|TOKEN|SECRET|PASSWORD)["']\s*:\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}]+)/gi;
 const sensitiveLabelPattern =
   /\b(?:client[_-]?secret|session[_-]?cookie|set-cookie|cookie)\s*[:=]\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\r\n,;]+)/gi;
-const standaloneAuthorizationPattern = /\b(?:basic|bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+const standaloneBasicAuthorizationPattern = /\bbasic\s+[A-Za-z0-9+/]+={0,2}/gi;
+const standaloneBearerAuthorizationPattern = /\bbearer\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+const minimumOpaqueBearerTokenLength = 24;
+const minimumBearerTokenSeparators = 2;
 const privateKeyPattern =
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|$)/g;
 const privateKeyMarkerPattern = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i;
@@ -26,7 +29,33 @@ type RedactionRule = {
   pattern: RegExp;
   classification: RedactionClass;
   replacement: string;
+  shouldRedact?: (match: string) => boolean;
 };
+
+function standaloneAuthorizationToken(match: string): string {
+  return match.replace(/^\s*(?:basic|bearer)\s+/i, "");
+}
+
+function isBasicCredential(match: string): boolean {
+  const token = standaloneAuthorizationToken(match);
+  if (token.length < 8 || token.length % 4 === 1) return false;
+  try {
+    const decoded = atob(token.padEnd(Math.ceil(token.length / 4) * 4, "="));
+    return decoded.includes(":");
+  } catch {
+    return false;
+  }
+}
+
+function isBearerCredential(match: string): boolean {
+  const token = standaloneAuthorizationToken(match);
+  const separators = token.match(/[._~+/=-]/g)?.length ?? 0;
+  return (
+    token.length >= minimumOpaqueBearerTokenLength ||
+    /[0-9]/.test(token) ||
+    separators >= minimumBearerTokenSeparators
+  );
+}
 
 const redactionRules: readonly RedactionRule[] = [
   {
@@ -65,9 +94,16 @@ const redactionRules: readonly RedactionRule[] = [
     replacement: "[REDACTED:SENSITIVE_CONTENT]"
   },
   {
-    pattern: standaloneAuthorizationPattern,
+    pattern: standaloneBasicAuthorizationPattern,
     classification: "credential",
-    replacement: "[REDACTED:CREDENTIAL]"
+    replacement: "[REDACTED:CREDENTIAL]",
+    shouldRedact: isBasicCredential
+  },
+  {
+    pattern: standaloneBearerAuthorizationPattern,
+    classification: "credential",
+    replacement: "[REDACTED:CREDENTIAL]",
+    shouldRedact: isBearerCredential
   }
 ];
 
@@ -76,10 +112,24 @@ function patternMatches(pattern: RegExp, value: string): boolean {
   return pattern.test(value);
 }
 
+function ruleMatches(rule: RedactionRule, value: string): boolean {
+  rule.pattern.lastIndex = 0;
+  let match = rule.pattern.exec(value);
+  while (match !== null) {
+    if (!rule.shouldRedact || rule.shouldRedact(match[0])) {
+      rule.pattern.lastIndex = 0;
+      return true;
+    }
+    match = rule.pattern.exec(value);
+  }
+  rule.pattern.lastIndex = 0;
+  return false;
+}
+
 export function containsUnredactedRunnerSecret(value: string): boolean {
   const decodedNewlines = value.replaceAll("\\n", "\n");
   return (
-    redactionRules.some((rule) => patternMatches(rule.pattern, decodedNewlines)) ||
+    redactionRules.some((rule) => ruleMatches(rule, decodedNewlines)) ||
     patternMatches(privateKeyMarkerPattern, decodedNewlines) ||
     patternMatches(incompleteRedactionPattern, decodedNewlines)
   );
@@ -95,7 +145,8 @@ export function redactRunnerEventText(value: string): {
   const classes = new Set<RedactionClass>();
   for (const rule of redactionRules) {
     rule.pattern.lastIndex = 0;
-    text = text.replace(rule.pattern, () => {
+    text = text.replace(rule.pattern, (match) => {
+      if (rule.shouldRedact && !rule.shouldRedact(match)) return match;
       replaced += 1;
       classes.add(rule.classification);
       return rule.replacement;


### PR DESCRIPTION
## Summary

- preserve ordinary authorization-like prose such as `Basic PlanWeave Example` instead of partially redacting it and failing normalized event generation
- recognize standalone Basic credentials by validating their Base64-decoded `user:password` shape
- keep standalone Bearer redaction for credential-like tokens while leaving explicit `Authorization:` fields fail-closed
- restore regression coverage at the text, browser-compatible runtime, ACP protocol persistence, and normalized event seams

## Verification

- `pnpm lint`
- `pnpm --filter @planweave-ai/runtime build`
- unit: 42 tests passed across `runnerContracts.test.ts` and `runnerEventRedactionBrowser.test.ts`
- core integration: 49 tests passed across `acpProtocolRedaction.test.ts`, `acpEventController.test.ts`, and `acpEvents.test.ts`

## Remaining risk

Standalone Bearer detection remains heuristic because unlabeled prose and opaque tokens share the same character set. Explicit authorization fields and structured credential keys retain unconditional fail-closed redaction.
